### PR TITLE
integrated a exclude variable for vimrc

### DIFF
--- a/plugin/phpfmt.vim
+++ b/plugin/phpfmt.vim
@@ -32,6 +32,10 @@ fun! PhpFmtFix(path)
         let command = command.' --prepasses='.g:phpfmt_prepasses_list
     endif
 
+    if exists('g:phpfmt_exclude_list')
+        let command = command.' --exclude='.g:phpfmt_exclude_list
+    endif
+
     if exists('g:phpfmt_psr1')
         let command = command.' --psr1'
     endif


### PR DESCRIPTION
Like for pass and prepass list, there is also an exclude variable, which can be set in the .vimrc to exclude specific formatting options.